### PR TITLE
Remove Indent from different files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,20 @@ val name := value
 ```
 
 ### Namespaces
-Create namespaces using `namespace name:` and use indentation. (separation: '.')
+Create namespaces using `namespace name:` and use the `end` keyword. (separation: '.')
 
 ### If, while and for
-Use indentation, and use the following syntax: `whatever cond:`. For `for`, use: `for i in list`, but classic syntax will also  be accepted `for int i=0; i<10; i++` or as wanted.
+Use the `end` keyword, and use the following syntax: `whatever cond:`. For `for`, use: `for i in list`, but classic syntax will also  be accepted `for int i=0; i<10; i++` or as wanted.
 
 ### Functions
-Use indentation, and use the reserved word `fun`. Define return type after args (optional).
+Use the `end` keyword, and use the reserved word `fun`. Define return type after args (optional).
 
 ```
 fun Main() char:
 ```
 
 ### Classes
-As everywhere, use indents. if you put `-> type` at the end of `class name:`, you are saying that this class will act as a type, instead of being a constructor that only saves things in memory using another type.
+As everywhere, use `end` to declare when the class ends. if you put `-> type` at the end of `class name:`, you are saying that this class will act as a type, instead of being a constructor that only saves things in memory using another type.
 
 With -> type:
 
@@ -67,6 +67,8 @@ class string: -> type
     fun __USE__():
         text = extl
         len = sizeof(text)
+    end
+end
 ```
 Explanation: extl and impl are from type classes, and extl is the external value (in `string name = "hi"`, extl would be "hi"), and impl means implicit: can't be changed, but can be accessed by other than the class itself. It also means it's calculated by the class automatically.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Explicit:
 ```
 int name = value //or any other type (builtin: int, char, float)
 ```
-Inferenced:
+Inferred:
 ```
 val name := value
 ```
@@ -66,7 +66,7 @@ class string: -> type
     impl int len
     fun __USE__():
         text = extl
-        len = bytes(text)
+        len = sizeof(text)
 ```
 Explanation: extl and impl are from type classes, and extl is the external value (in `string name = "hi"`, extl would be "hi"), and impl means implicit: can't be changed, but can be accessed by other than the class itself. It also means it's calculated by the class automatically.
 
@@ -78,15 +78,13 @@ To create a pointer it's also the C way.
 
 `int* name = &reference`
 ### Input and output
-I will make a C lib called stdio, with, at least, two functions:
+I will make a lib with at least these two functions: (_For single character output, use `scho`_)
 
 `std.out.print(char[])`
 
 and
 
 `std.in.ask(&ref, char[])`
-
-_For a SINGLE character output I will add scho()_
 
 ## Status
 Right now, this is the current development of every feature:

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 > This is temporary, as can change in any moment.
 
 ## Approach
-**Gravel** is a **IN DEVELOPMENT** programming language. It's made to have a simple and neat sintax while having all low level power.
+**Gravel** is a **IN DEVELOPMENT** programming language. It's made to have a simple and neat syntax while having all low level power.
 
-## Sytax
-_Note: Sintax is really variable in this early-development, as this is **JUST PLANNING**_
+## Syntax
+_Note: Syntax is really variable in this early-development, as this is **JUST PLANNING**_
 
 ### Packages
-For using files as libaries, use packages, so you will need to use the package name instead of the path.
+For using files as libraries, use packages, so you will need to use the package name instead of the path.
 
 ```
 package: string
@@ -31,7 +31,7 @@ import ("string", "stdio", "math", "rand")
 ```
 
 ### Variables
-There are two ways of defining variables: explicitaly and inferenced.
+There are two ways of defining variables: explicitly and inferenced.
 
 Explicit:
 ```
@@ -46,7 +46,7 @@ val name := value
 Create namespaces using `namespace name:` and use indentation. (separation: '.')
 
 ### If, while and for
-Use indentation, and use the following syntax: `whatever cond:`. For `for`, use: `for i in list`, but classic sintax will also  be accepted `for int i=0; i<10; i++` or as wanted.
+Use indentation, and use the following syntax: `whatever cond:`. For `for`, use: `for i in list`, but classic syntax will also  be accepted `for int i=0; i<10; i++` or as wanted.
 
 ### Functions
 Use indentation, and use the reserved word `fun`. Define return type after args (optional).
@@ -56,7 +56,7 @@ fun Main() char:
 ```
 
 ### Classes
-As everywhere, use indents. if you put `-> type` at the end of `class name:`, you are saying that this class will act as a type, isntead of being a constructor that only saves things in memory using another type.
+As everywhere, use indents. if you put `-> type` at the end of `class name:`, you are saying that this class will act as a type, instead of being a constructor that only saves things in memory using another type.
 
 With -> type:
 
@@ -107,5 +107,5 @@ This is the Gravel _launcher_. This launcher goal is to provide basic CLI tools 
 Use the following pipeline for executing a file.
 
 ```powershell
-gravel run main.grv dependences path space separated.
+gravel run main.grv dependencies path space separated.
 ```

--- a/include/tokens.h
+++ b/include/tokens.h
@@ -15,15 +15,16 @@ typedef enum {
     TOKEN_NAME,
     TOKEN_TYPEIS_LIST, //for char[][], int[], etc
     TOKEN_EQUAL,
-    TOKEN_INDENT,
-    TOKEN_DEDENT,
     TOKEN_AMPERSAND,
     TOKEN_NEWLINE,
     TOKEN_RPAREN,
     TOKEN_LPAREN,
     TOKEN_ARROW,
     TOKEN_QUOTE,
-    TOKEN_SCHO
+    
+    //Keywords
+    TOKEN_SCHO,
+    TOKEN_END
 } TokenType;
 
 

--- a/libs/boolean.grv
+++ b/libs/boolean.grv
@@ -13,14 +13,19 @@ namespace std:
 				bvalue = "false"
 			else:
 				bvalue = "true"
+			end
+		end
 
 		fun getPair():
 			return (bvalue, ivalue)
+		end
 
 		fun toCustom(char[] trueStr, char[] falseStr):
 			if ivalue == 0:
 				return falseStr
+			end
 			return trueStr
+		end
 		fun fromCustom(char[] text, char[] trueStr, char[] falseStr):
 			if text == falseStr:
 				ivalue = 0
@@ -32,6 +37,8 @@ namespace std:
 				ivalue = 0
 				bvalue = "false"
 				std.warn.logWarning("Given char[] is invalid.")
+			end
+		end
 				
 		fun toggle():
 			if ivalue:
@@ -40,6 +47,10 @@ namespace std:
 			else:
 				ivalue = 1
 				bvalue = "true"
-	group bool:
+			end
+		end
+	namespace bool:
 		const boolean TRUE  = 1
 		const boolean FALSE = 0
+	end
+end

--- a/libs/random.grv
+++ b/libs/random.grv
@@ -3,6 +3,7 @@ package: random
 namespace rand:
 	fun initRNG():
 		int seed     = 1
+	end
 
 	fun randint(int min, int max):
 		int module = 65536
@@ -12,5 +13,6 @@ namespace rand:
 		seed = ((seed * mul) + increm) % module
 
 		return min + (seed ( % (max-min + 1)))
-
+	end
+end
 

--- a/libs/random.grv
+++ b/libs/random.grv
@@ -4,13 +4,13 @@ namespace rand:
 	fun initRNG():
 		int seed     = 1
 
-fun randint(int min, int max):
-	int module = 65536
-	int mul       = 25173
-	int increm  = 13849
-	
-	seed = ((seed * mul) + increm) % module
+	fun randint(int min, int max):
+		int module = 65536
+		int mul       = 25173
+		int increm  = 13849
+		
+		seed = ((seed * mul) + increm) % module
 
-return min + (seed ( % (max-min + 1)))
+		return min + (seed ( % (max-min + 1)))
 
 

--- a/libs/string.grv
+++ b/libs/string.grv
@@ -8,24 +8,32 @@ namespace std:
 		fun __USE__():
 			text   = extl
 			length = sizeof(text)
+		end
 		
 		fun replace(char rsrc, char res):
 			char* ractl = &text[0]
 			while *ractl != '\0':
 				if *ractl == rsrc:
 					*ractl = res
+				end
 				ractl++
+			end
+		end
 		
 		fun contains(char src):
 			char* cactl = &text[0]
 			while *cactl != '\0':
 				if *cactl == src:
 					return 1
+				end
 				cactl++
+			end
 			return 0
+		end
 
 		fun at(int idx):
 			return text[idx]
+		end
 
 		fun where(char src):
 			char* wactl = &text[0]
@@ -33,7 +41,9 @@ namespace std:
 			while *wactl != '\0':
 				if *wactl == src:
 					return idx
+				end
 				idx++
+			end
 			return -1
-			
+		end
 				

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -13,7 +13,7 @@ Token tokens[512];
 int token_count = 0;
 
 void skipBlank(const char** current) {
-    while (**current == ' ') {
+    while (**current == ' ' || **current = '\t') {
         (*current)++;
     }
 }
@@ -60,9 +60,6 @@ void tokenize(const char* file) {
                 } else {
                     raiseError("Unexpected token");
                 }
-                break;
-            case '\t':
-                tokens[token_count].type = TOKEN_INDENT;
                 break;
             case '\n':
                 tokens[token_count].type = TOKEN_NEWLINE;
@@ -119,6 +116,8 @@ void tokenize(const char* file) {
                         tokens[token_count].type = TOKEN_FLOAT;
                     } else if (strcmp(buffer, "char") == 0) {
                         tokens[token_count].type = TOKEN_CHAR;
+                    } else if (strcmp(buffer, "end") == 0) {
+                        tokens[token_count].type = TOKEN_END;
 
                     } else {
                         tokens[token_count].type = TOKEN_NAME;


### PR DESCRIPTION
Closes #4 
Removed indent from:
+ tokens.h
+ tokens.c
+ boolean.grv
+ string.grv
+ random.grv
+ readme.md

Now, instead of using indents, to declare the end of different things, use `end`.