### PR TITLE
Fixes

### DIFF
--- a/main.grv
+++ b/main.grv
@@ -1,11 +1,11 @@
 scho('H')
-scho('e')
+val a=65
 scho('l')
 scho('l')
 scho('o')
 scho(',')
 scho(' ')
-scho('W')
+scho(a)
 scho('o')
 scho('r')
 scho('l')

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@ int main(int argc, char *argv[]) {
 
     if(hasArg(&ctx, "run")) {
         tokenizeFile(getArg(&ctx, "run"));
+        
     }
     
 

--- a/src/tollvm.c
+++ b/src/tollvm.c
@@ -142,5 +142,6 @@ int to_llvm_ir(const Token* tokens, int token_count) {
 
     fclose(outf);
     printf("Compiled Succesfully");
+    exit(0);
     return 0;
 }


### PR DESCRIPTION
Now variables can be used as int (put 65 instead of 'A'), message shown when compiled
Closes #11
Closes #12 