### PR TITLE
Added a error message for when the file to run doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Right now, this is the current development of every feature:
 |Functions, namespaces, if, while, repeat| 4/5 |
 |Packages, pointers, import and basic packages | NOT STARTED |
 
+To propose or vote on small syntax changes, please go to discussions.
+
 ## Launcher
 This is the Gravel _launcher_. This launcher goal is to provide basic CLI tools to run your Gravel code.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Array Methods:
 - length/size -> the amount of values
 - purity -> returns a boolean of true if all values are truthy; returns false if there is a falsy value.
 - divide -> argue an integer; it will split the array at the index of the given integer:
-`['foobar', 'baz', 'qux'].divide(2) # => ['foobar', 'baz']`
+`['foobar', 'baz', 'qux'].divide(2) // => ['foobar', 'baz']`
 Note that it will discard every value after the given index.
 
 Dictionary Methods:

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -244,7 +244,10 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
 
 void tokenizeFile(char* file, ARGS_CONTEX* ctx) {
     FILE* input = fopen(file, "r");
-    if (!input) return;
+    if (!input) {
+        raiseError("File does not exist or cannot be read", "E0031");
+        return ;
+    }
 
     char line[256];
     size_t buffer_capacity = 2048;


### PR DESCRIPTION
- Added a `raiseError()` in `tokenizeFile` for when the file read fails (either when the file doesn't exist or is unable to be read for some other reason)
- Uses the error ID "E0031"
- Fixes #90 