### PR TITLE
Added while and for loops

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -177,7 +177,9 @@ typedef enum {
     NODE_CONSTANT,
     NODE_FUN_DEF,
     NODE_CALL,
-    NODE_IF
+    NODE_IF,
+    NODE_WHILE,
+    NODE_FOR
 } ASTNodeType;
 
 typedef struct ASTNode {
@@ -250,8 +252,12 @@ flowchart LR
     A[parse_expression] -->|calls| B[parse_equality]
     
     %% Equality Level
-    B -->|1. calls| C[parse_additive]
-    B -->|2. loops while TOKEN_EQUAL| C
+    B -->|1. calls| R[parse_relational]
+    B -->|2. loops while TOKEN_EQUAL / TOKEN_NE| R
+    
+    %% Relational Level
+    R -->|1. calls| C[parse_additive]
+    R -->|2. loops while TOKEN_LT / TOKEN_GT / TOKEN_LE / TOKEN_GE| C
     
     %% Additive Level
     C -->|1. calls| D[parse_multiplicative]
@@ -267,11 +273,15 @@ flowchart LR
         E -->|Variable / Call| G[NODE_VARIABLE / NODE_CALL]
         E -->|TOKEN_REPEAT| H[parse_repeat]
         E -->|TOKEN_IF / ELSE| I[parse_if]
+        E -->|TOKEN_WHILE| J[parse_while]
+        E -->|TOKEN_FOR| K[parse_for]
     end
 
     %% Recursion Backtrack
     H -.->|parses body statements| A
     I -.->|parses condition & statements| A
+    J -.->|parses condition & body| A
+    K -.->|parses header & body| A
 ```  
 
 This flow makes that operations are solved using the right precedence and that expressions and equality work as expected.
@@ -368,6 +378,49 @@ As before, I will now explain what every field does.
 As we have seen, there is no "elseif" node, because we handle `elseif` on another way:
 
 When doing so, a NodeIf is attached to the else_node, making a else if chain.
+
+### While and For
+Loops share a simple design. While is just a condition plus a body, while `for` adds an init and an increment around the same structure:
+
+```c
+        struct {
+            struct ASTNode* condition;
+            struct ASTNode** statements;
+            int count;
+        } while_stmt;
+
+        struct {
+            struct ASTNode* init;
+            struct ASTNode* condition;
+            struct ASTNode* increment;
+            struct ASTNode** statements;
+            int count;
+        } for_stmt;
+```
+
+| **Name**    | **Function** |
+|-------------|--------------|
+| condition   | Expression evaluated before every iteration; the loop runs while it is truthy. |
+| statements / count | The loop body, as an array of AST nodes. |
+| init        | Only on `for`: executed once before the first check (e.g. `int i=0`). |
+| increment   | Only on `for`: executed after each iteration (e.g. `i++`). |
+
+The classic `for int i=0; i<10; i++` is stored as-is, while the modern
+`for i in n` is desugared at parse time into an init (`i := 0`), a condition
+(`i < n`) and an increment (`i++`), so both forms share the same codegen.
+
+At LLVM emission, every loop gets three fresh basic blocks:
+`loopcond<N>`, `loopbody<N>` and `loopend<N>`. The condition is compiled at
+the start of `loopcond<N>` and a `br` decides whether to enter the body or
+exit. The body ends with a `br` back to `loopcond<N>`, and (for `for`) the
+increment is emitted just before that back-edge.
+
+If the body ends in a `return`, the back-edge (and the `for` increment) is
+skipped, since the `return` already exits the function.
+
+Because every variable is stored as a global, loop variables are globals
+too: declaring the same variable in nested loops (e.g. two `for i ...`
+loops) reuses the same global and overwrites the outer counter.
 
 ### Namespaces
 Namespaces are way simpler that they may seem: they don't even have  a struct!

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -9,6 +9,8 @@ sentence    = scho
             | end
             | namespace
             | if
+            | while
+            | for
             | fun_def
             | fun_call
             | return
@@ -21,7 +23,8 @@ sentence    = scho
 letter      = "a" .. "z" | "A" .. "Z" ;
 digit       = "0" .. "9" ;
 
-condition   = value, '==', value ;
+cmp_op      = '==' | '!=' | '<' | '>' | '<=' | '>=' ;
+condition   = value, cmp_op, value ;
 operation   = value, ('+' | '-' | '*' | '/' | '%'), value ;
 negation    = '-', value ;
 
@@ -52,6 +55,16 @@ elseif      = 'elseif', condition, sentence*,
 
 else        = 'else', sentence*, end ;
 
+while       = 'while', condition, sentence*, end ;
+
+for         = 'for', (for_in | for_classic), sentence*, end ;
+
+for_in      = name, 'in', value ;
+
+for_classic = for_init, ';', condition, ';', for_update ;
+for_init    = explicit_var | inferred_var | variable_mod ;
+for_update  = variable_mod ;
+
 args        = '(', [type, name, {',', type, name}], ')' ;
 
 type        = 'int'
@@ -69,7 +82,9 @@ return      = 'return', value ;
 inferred_var= 'val', name, ':=', value ;
 explicit_var= type, name, '=', value ;
 
-variable_mod= name, '=', value ;
+variable_mod= name, ('=' | ':=' | '+=' | '-=' | '*=' | '/=' | '%='), value
+            | name, ('++' | '--')
+            ;
 
 repeat      = 'repeat', value, sentence*, end ;
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ val rounded_math.e := 2
 ```
 
 ### If, while and for
-Use the `end` keyword, and use the following syntax: `whatever cond`. For `for`, use: `for i in list`, but classic syntax will also  be accepted `for int i=0; i<10; i++` or as wanted.
+Use the `end` keyword, and use the following syntax: `whatever cond`. For `for`, use: `for i in n`, which iterates `i` from `0` to `n-1`, but classic syntax will also be accepted `for int i=0; i<10; i++` or as wanted.
 
 Traditional for-loop:
 ```
@@ -87,8 +87,8 @@ end
 
 Modern for-loop:
 ```
-for entry in list
-    std.out.print(entry)
+for i in 5
+    std.out.print(i)
 end
 ```
 
@@ -203,7 +203,7 @@ Right now, this is the current development of every feature:
 |Parser   |Working|
 |LLVM converter |Working|
 |Variables, types and classes | 1/3 |
-|Functions, namespaces, if, while, repeat| 4/5 |
+|Functions, namespaces, if, while, for, repeat| 5/6 |
 |Packages, pointers, import and basic packages | NOT STARTED |
 
 To propose or vote on small syntax changes, please go to discussions.
@@ -256,6 +256,7 @@ This repo includes a `bench.grv` file with 33576 tokens. You can execute it to t
 - val namespace.gettheanother := 65
 - Line comments // and block comments /* */
 - If elseif else
+- While and for loops (with comparison, increment/decrement and compound-assignment operators)
 - Int args and int/void return functions
 - Reassing varibles
 
@@ -433,3 +434,8 @@ This repo includes a `bench.grv` file with 33576 tokens. You can execute it to t
 - Improve Python LLVM executor
 - Use Python always to execute LLVM
 - Fix sanitizer warnings
+- Add `while` and `for` loops (classic `for int i=0; i<10; i++` and modern `for i in n`)
+- Add comparison operators (`<`, `>`, `<=`, `>=`, `!=`)
+- Add increment/decrement (`i++`, `i--`) and compound assignment (`+=`, `-=`, `*=`, `/=`, `%=`) operators
+- Fix tokenizer never emitting `,`, enabling multi-argument functions and calls
+- Update grammar documentation and add loop tests

--- a/include/ast.h
+++ b/include/ast.h
@@ -15,6 +15,8 @@ typedef enum {
     NODE_FUN_DEF,
     NODE_CALL,
     NODE_IF,
+    NODE_WHILE,
+    NODE_FOR,
     NODE_RETURN,
     NODE_REASSIGN
 } ASTNodeType;
@@ -68,6 +70,20 @@ typedef struct ASTNode {
         } if_stmt;
 
         struct {
+            struct ASTNode* condition;
+            struct ASTNode** statements;
+            int count;
+        } while_stmt;
+
+        struct {
+            struct ASTNode* init;
+            struct ASTNode* condition;
+            struct ASTNode* increment;
+            struct ASTNode** statements;
+            int count;
+        } for_stmt;
+
+        struct {
             struct ASTNode* value;
         } return_stmt;
 
@@ -110,4 +126,6 @@ ASTNode* parse_expression(const Token* t, int* c, const char* ns);
 ASTNode* parse_statement(const Token* t, int* c, const char* ns);
 ASTNode* parse_repeat(const Token* t, int* c, const char* ns);
 ASTNode* parse_if(const Token* t, int* c, const char* ns);
+ASTNode* parse_while(const Token* t, int* c, const char* ns);
+ASTNode* parse_for(const Token* t, int* c, const char* ns);
 void print_ast(const ASTNode* node, int depth);

--- a/include/tokens.h
+++ b/include/tokens.h
@@ -25,6 +25,19 @@ typedef enum {
     TOKEN_COMMA,
     TOKEN_L_INT,
     TOKEN_L_FLOAT,
+    TOKEN_SEMICOLON,
+    TOKEN_LT, // <
+    TOKEN_GT, // >
+    TOKEN_LE, // <=
+    TOKEN_GE, // >=
+    TOKEN_NE, // !=
+    TOKEN_INC, // ++
+    TOKEN_DEC, // --
+    TOKEN_ADD_ASSIGN, // +=
+    TOKEN_SUB_ASSIGN, // -=
+    TOKEN_STAR_ASSIGN, // *=
+    TOKEN_DIV_ASSIGN, // /=
+    TOKEN_MOD_ASSIGN, // %=
 
     //Keywords
     TOKEN_SCHO,
@@ -40,6 +53,9 @@ typedef enum {
     TOKEN_EXTL,
     TOKEN_RETURN,
     TOKEN_REPEAT,
+    TOKEN_WHILE,
+    TOKEN_FOR,
+    TOKEN_IN,
     TOKEN_VAR_DEF, // val
     TOKEN_CONST
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -81,6 +81,100 @@ Token* advance(const Token* t, int* c) {
     return (Token*)&t[(*c)-1];
 }
 
+static ASTNode* make_literal(const char* value) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_LITERAL;
+    snprintf(node->data.literal.value, sizeof(node->data.literal.value), "%s", value);
+    return node;
+}
+
+static ASTNode* make_variable(const char* name) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_VARIABLE;
+    snprintf(node->data.literal.value, sizeof(node->data.literal.value), "%s", name);
+    return node;
+}
+
+static ASTNode* make_binary(TokenType op, ASTNode* left, ASTNode* right) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_BINARY_OP;
+    node->data.binary_op.op = op;
+    node->data.binary_op.left = left;
+    node->data.binary_op.right = right;
+    return node;
+}
+
+static ASTNode* make_reassign(const char* name, ASTNode* value) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_REASSIGN;
+    snprintf(node->data.reassign.name, sizeof(node->data.reassign.name), "%s", name);
+    node->data.reassign.value = value;
+    return node;
+}
+
+static void qualify_name(char* dest, size_t dest_size, const char* ns, const char* name);
+
+// Parse an assignment-style statement: `name = expr`, `name += expr`,
+// `name++`, etc. All forms are desugared into a plain NODE_REASSIGN.
+static ASTNode* parse_update(const Token* t, int* c, const char* ns) {
+    Token* current = peek(t, c);
+    if (current->type != TOKEN_NAME) {
+        raiseError("Expected variable name in assignment", "E0025");
+        return NULL;
+    }
+
+    Token* name_token = advance(t, c);
+    char qualified[64];
+    qualify_name(qualified, sizeof(qualified), ns, name_token->value);
+
+    Token* op = peek(t, c);
+    ASTNode* value = NULL;
+    switch (op->type) {
+        case TOKEN_INC:
+            advance(t, c);
+            value = make_binary(TOKEN_ADD, make_variable(qualified), make_literal("1"));
+            break;
+        case TOKEN_DEC:
+            advance(t, c);
+            value = make_binary(TOKEN_SUB, make_variable(qualified), make_literal("1"));
+            break;
+        case TOKEN_ASSIGN:
+        case TOKEN_VAR_INFER:
+            advance(t, c);
+            value = parse_expression(t, c, ns);
+            break;
+        case TOKEN_ADD_ASSIGN:
+            advance(t, c);
+            value = make_binary(TOKEN_ADD, make_variable(qualified), parse_expression(t, c, ns));
+            break;
+        case TOKEN_SUB_ASSIGN:
+            advance(t, c);
+            value = make_binary(TOKEN_SUB, make_variable(qualified), parse_expression(t, c, ns));
+            break;
+        case TOKEN_STAR_ASSIGN:
+            advance(t, c);
+            value = make_binary(TOKEN_STAR, make_variable(qualified), parse_expression(t, c, ns));
+            break;
+        case TOKEN_DIV_ASSIGN:
+            advance(t, c);
+            value = make_binary(TOKEN_DIV, make_variable(qualified), parse_expression(t, c, ns));
+            break;
+        case TOKEN_MOD_ASSIGN:
+            advance(t, c);
+            value = make_binary(TOKEN_MODULO, make_variable(qualified), parse_expression(t, c, ns));
+            break;
+        default:
+            raiseError("Expected assignment operator after name", "E0025");
+            break;
+    }
+
+    return make_reassign(qualified, value);
+}
+
 // Copy `name` into dest, prefixed with the current namespace unless the name
 // is already qualified. Errors out rather than overflowing or truncating.
 static void qualify_name(char* dest, size_t dest_size, const char* ns, const char* name) {
@@ -230,6 +324,10 @@ ASTNode* parse_primary(const Token* t, int* c, const char* ns) {
         return parse_repeat(t, c, ns);
     } else if (current->type == TOKEN_ELSE || current->type == TOKEN_IF || current->type == TOKEN_ELSEIF) {
         return parse_if(t,c,ns);
+    } else if (current->type == TOKEN_WHILE) {
+        return parse_while(t, c, ns);
+    } else if (current->type == TOKEN_FOR) {
+        return parse_for(t, c, ns);
     } else if (current->type == TOKEN_FUN) {
         raiseError("Unexpected token: function definitions must be parsed at the top level", "E0009");
         return NULL;
@@ -243,11 +341,31 @@ ASTNode* parse_expression(const Token* t, int* c, const char* ns) {
     return parse_equality(t, c, ns);
 }
 
-ASTNode* parse_equality(const Token* t, int* c, const char* ns) {
+ASTNode* parse_relational(const Token* t, int* c, const char* ns) {
     ASTNode* left = parse_additive(t, c, ns);
-    while (peek(t, c)->type == TOKEN_EQUAL) {
+
+    while (peek(t, c)->type == TOKEN_LT || peek(t, c)->type == TOKEN_GT ||
+           peek(t, c)->type == TOKEN_LE || peek(t, c)->type == TOKEN_GE) {
         Token* op_token = advance(t, c);
         ASTNode* right = parse_additive(t, c, ns);
+
+        ASTNode* bin_node = (ASTNode*)malloc(sizeof(ASTNode));
+        if (!bin_node) raiseError("Memory allocation failed", "E0004");
+        bin_node->type = NODE_BINARY_OP;
+        bin_node->data.binary_op.op = op_token->type;
+        bin_node->data.binary_op.left = left;
+        bin_node->data.binary_op.right = right;
+
+        left = bin_node;
+    }
+    return left;
+}
+
+ASTNode* parse_equality(const Token* t, int* c, const char* ns) {
+    ASTNode* left = parse_relational(t, c, ns);
+    while (peek(t, c)->type == TOKEN_EQUAL || peek(t, c)->type == TOKEN_NE) {
+        Token* op_token = advance(t, c);
+        ASTNode* right = parse_relational(t, c, ns);
 
         ASTNode* bin_node = (ASTNode*)malloc(sizeof(ASTNode));
         if (!bin_node) raiseError("Memory allocation failed", "E0004");
@@ -349,17 +467,12 @@ ASTNode* parse_statement(const Token* t, int* c, const char* ns) {
 
     else if (current->type == TOKEN_NAME) {
         Token* next = (Token*)&t[*c + 1];
-        if (next->type == TOKEN_ASSIGN || next->type == TOKEN_VAR_INFER) {
-            ASTNode* result = (ASTNode*)malloc(sizeof(ASTNode));
-            if (!result) raiseError("Memory allocation failed", "E0004");
-
-            result->type = NODE_REASSIGN;
-            Token* name_token = advance(t, c);
-
-            qualify_name(result->data.reassign.name, sizeof(result->data.reassign.name), ns, name_token->value);
-            advance(t, c); //Consume = or :=
-            result->data.reassign.value = parse_expression(t, c, ns);
-            return result;
+        if (next->type == TOKEN_ASSIGN || next->type == TOKEN_VAR_INFER ||
+            next->type == TOKEN_ADD_ASSIGN || next->type == TOKEN_SUB_ASSIGN ||
+            next->type == TOKEN_STAR_ASSIGN || next->type == TOKEN_DIV_ASSIGN ||
+            next->type == TOKEN_MOD_ASSIGN || next->type == TOKEN_INC ||
+            next->type == TOKEN_DEC) {
+            return parse_update(t, c, ns);
         }
 
         return parse_expression(t, c, ns);
@@ -394,6 +507,10 @@ ASTNode* parse_statement(const Token* t, int* c, const char* ns) {
         return parse_repeat(t, c, ns);
     } else if (current->type == TOKEN_IF) {
         return parse_if(t, c, ns);
+    } else if (current->type == TOKEN_WHILE) {
+        return parse_while(t, c, ns);
+    } else if (current->type == TOKEN_FOR) {
+        return parse_for(t, c, ns);
     } else {
         return parse_expression(t, c, ns);
     }
@@ -447,6 +564,155 @@ ASTNode* parse_repeat(const Token* t, int* c, const char* ns) {
     }
 
     return newNode;
+}
+
+// Collect statements until `end` (or EOF). On success the trailing `end`
+// has been consumed and the array is returned; `out_count` receives its size.
+static ASTNode** parse_block_statements(const Token* t, int* c, const char* ns, int* out_count, const char* error_msg) {
+    int cap = 8;
+    int count = 0;
+    ASTNode** statements = (ASTNode**)malloc(sizeof(ASTNode*) * cap);
+    if (!statements) raiseError("Memory allocation failed", "E0004");
+
+    while (peek(t, c)->type != TOKEN_END && peek(t, c)->type != TOKEN_EOF) {
+        ASTNode* inner = parse_statement(t, c, ns);
+        if (inner != NULL) {
+            if (count >= cap) {
+                cap *= 2;
+                ASTNode** tmp = (ASTNode**)realloc(statements, sizeof(ASTNode*) * cap);
+                if (!tmp) {
+                    free(statements);
+                    raiseError("Memory allocation failed while expanding block statements", "E0004");
+                }
+                statements = tmp;
+            }
+            statements[count++] = inner;
+        }
+    }
+
+    if (peek(t, c)->type == TOKEN_END) {
+        advance(t, c);
+    } else {
+        free(statements);
+        raiseError("Unexpected end of file: missing 'end' for block", (char*)error_msg);
+    }
+
+    *out_count = count;
+    return statements;
+}
+
+ASTNode* parse_while(const Token* t, int* c, const char* ns) {
+    advance(t, c); // consume 'while'
+
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_WHILE;
+    node->data.while_stmt.condition = NULL;
+
+    ASTNode* condition = NULL;
+    if (peek(t, c)->type == TOKEN_LPAREN) {
+        advance(t, c);
+        condition = parse_expression(t, c, ns);
+        if (peek(t, c)->type == TOKEN_RPAREN) {
+            advance(t, c);
+        } else {
+            raiseError("Missing ')' after while condition", "E0023.2");
+        }
+    } else {
+        condition = parse_expression(t, c, ns);
+    }
+    node->data.while_stmt.condition = condition;
+
+    node->data.while_stmt.statements = parse_block_statements(t, c, ns, &node->data.while_stmt.count, "E0010.2");
+
+    return node;
+}
+
+ASTNode* parse_for(const Token* t, int* c, const char* ns) {
+    advance(t, c); // consume 'for'
+
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    if (!node) raiseError("Memory allocation failed", "E0004");
+    node->type = NODE_FOR;
+    node->data.for_stmt.init = NULL;
+    node->data.for_stmt.condition = NULL;
+    node->data.for_stmt.increment = NULL;
+
+    Token* current = peek(t, c);
+
+    // Modern for: `for entry in list` - iterates the loop variable from 0
+    // while it is smaller than the value of the given expression.
+    if (current->type == TOKEN_NAME && ((Token*)&t[*c + 1])->type == TOKEN_IN) {
+        Token* var_token = advance(t, c); // consume loop variable name
+        advance(t, c); // consume 'in'
+
+        char qualified[64];
+        qualify_name(qualified, sizeof(qualified), ns, var_token->value);
+
+        ASTNode* list_value = parse_expression(t, c, ns);
+
+        ASTNode* init = (ASTNode*)malloc(sizeof(ASTNode));
+        if (!init) raiseError("Memory allocation failed", "E0004");
+        init->type = NODE_DECLARATION;
+        strcpy(init->data.var_decl.name, qualified);
+        init->data.var_decl.value = make_literal("0");
+
+        node->data.for_stmt.init = init;
+        node->data.for_stmt.condition = make_binary(TOKEN_LT, make_variable(qualified), list_value);
+        node->data.for_stmt.increment = make_reassign(qualified, make_binary(TOKEN_ADD, make_variable(qualified), make_literal("1")));
+    }
+    // Classic for: `for int i=0; i<10; i++` or `for i=0; i<10; i=i+1`
+    else if (current->type == TOKEN_INT || current->type == TOKEN_VAR_DEF ||
+             current->type == TOKEN_CONST || current->type == TOKEN_NAME) {
+        ASTNode* init = NULL;
+
+        if (current->type == TOKEN_INT) {
+            advance(t, c);
+            Token* name_token = peek(t, c);
+            if (name_token->type != TOKEN_NAME) raiseError("Missing variable name after 'int'", "E0005");
+            advance(t, c);
+            if (peek(t, c)->type != TOKEN_ASSIGN) raiseError("Missing '=' in for-loop init", "E0006");
+            advance(t, c);
+
+            init = (ASTNode*)malloc(sizeof(ASTNode));
+            if (!init) raiseError("Memory allocation failed", "E0004");
+            init->type = NODE_DECLARATION;
+            qualify_name(init->data.var_decl.name, sizeof(init->data.var_decl.name), ns, name_token->value);
+            init->data.var_decl.value = parse_expression(t, c, ns);
+        } else if (current->type == TOKEN_VAR_DEF || current->type == TOKEN_CONST) {
+            advance(t, c);
+            Token* name_token = peek(t, c);
+            if (name_token->type != TOKEN_NAME) raiseError("Missing variable name after 'val'", "E0005");
+            advance(t, c);
+            if (peek(t, c)->type != TOKEN_VAR_INFER) raiseError("Missing ':=' in for-loop init", "E0006");
+            advance(t, c);
+
+            init = (ASTNode*)malloc(sizeof(ASTNode));
+            if (!init) raiseError("Memory allocation failed", "E0004");
+            init->type = NODE_DECLARATION;
+            qualify_name(init->data.var_decl.name, sizeof(init->data.var_decl.name), ns, name_token->value);
+            init->data.var_decl.value = parse_expression(t, c, ns);
+        } else { // TOKEN_NAME
+            init = parse_update(t, c, ns);
+        }
+        node->data.for_stmt.init = init;
+
+        if (peek(t, c)->type != TOKEN_SEMICOLON) raiseError("Expected ';' after for-loop init", "E0026");
+        advance(t, c);
+
+        node->data.for_stmt.condition = parse_expression(t, c, ns);
+
+        if (peek(t, c)->type != TOKEN_SEMICOLON) raiseError("Expected ';' after for-loop condition", "E0026");
+        advance(t, c);
+
+        node->data.for_stmt.increment = parse_update(t, c, ns);
+    } else {
+        raiseError("Expected loop header after 'for'", "E0024");
+    }
+
+    node->data.for_stmt.statements = parse_block_statements(t, c, ns, &node->data.for_stmt.count, "E0010.3");
+
+    return node;
 }
 
 ASTNode* parse(const Token* tokens, int count) {

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -59,18 +59,37 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
 
         switch (*source) {
             case '+':
-                tokens[token_count].type = TOKEN_ADD;
+                if (*(source + 1) == '+') {
+                    tokens[token_count].type = TOKEN_INC;
+                    source++;
+                } else if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_ADD_ASSIGN;
+                    source++;
+                } else {
+                    tokens[token_count].type = TOKEN_ADD;
+                }
                 break;
             case '-':
                 if (*(source+1) == '>') {
                     tokens[token_count].type = TOKEN_ARROW;
+                    source++;
+                } else if (*(source + 1) == '-') {
+                    tokens[token_count].type = TOKEN_DEC;
+                    source++;
+                } else if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_SUB_ASSIGN;
                     source++;
                 } else { 
                     tokens[token_count].type = TOKEN_SUB;
                 }
                 break;
             case '*':
-                tokens[token_count].type = TOKEN_STAR;
+                if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_STAR_ASSIGN;
+                    source++;
+                } else {
+                    tokens[token_count].type = TOKEN_STAR;
+                }
                 break;
             case '/':
                 if (*(source + 1) == '/') {
@@ -88,15 +107,51 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
                     }
                     source += 2; // skip "*/"
                     continue;
+                } else if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_DIV_ASSIGN;
+                    source++;
                 } else {
                     tokens[token_count].type = TOKEN_DIV;
                 }
                 break;
             case '%':
-                tokens[token_count].type = TOKEN_MODULO;
+                if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_MOD_ASSIGN;
+                    source++;
+                } else {
+                    tokens[token_count].type = TOKEN_MODULO;
+                }
+                break;
+            case '<':
+                if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_LE;
+                    source++;
+                } else {
+                    tokens[token_count].type = TOKEN_LT;
+                }
+                break;
+            case '>':
+                if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_GE;
+                    source++;
+                } else {
+                    tokens[token_count].type = TOKEN_GT;
+                }
+                break;
+            case '!':
+                if (*(source + 1) == '=') {
+                    tokens[token_count].type = TOKEN_NE;
+                    source++;
+                } else {
+                    raiseError("Unexpected token '!'", "E0001");
+                }
+                break;
+            case ';':
+                tokens[token_count].type = TOKEN_SEMICOLON;
                 break;
             case ',':
                 tokens[token_count].type = TOKEN_COMMA;
+                break;
             case '=':
                 if (*(source + 1) == '=') {
                     tokens[token_count].type = TOKEN_EQUAL;
@@ -196,6 +251,12 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
                         tokens[token_count].type = TOKEN_EXTL;
                     } else if (strcmp(buffer, "repeat") == 0) {
                         tokens[token_count].type = TOKEN_REPEAT;
+                    } else if (strcmp(buffer, "while") == 0) {
+                        tokens[token_count].type = TOKEN_WHILE;
+                    } else if (strcmp(buffer, "for") == 0) {
+                        tokens[token_count].type = TOKEN_FOR;
+                    } else if (strcmp(buffer, "in") == 0) {
+                        tokens[token_count].type = TOKEN_IN;
                     } else if (strcmp(buffer, "const") == 0) {
                         tokens[token_count].type = TOKEN_CONST;
                     } else if (strcmp(buffer, "return") == 0) {

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -95,6 +95,8 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
             case '%':
                 tokens[token_count].type = TOKEN_MODULO;
                 break;
+            case ',':
+                tokens[token_count].type = TOKEN_COMMA;
             case '=':
                 if (*(source + 1) == '=') {
                     tokens[token_count].type = TOKEN_EQUAL;

--- a/src/tollvm.c
+++ b/src/tollvm.c
@@ -85,6 +85,22 @@ static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
         return;
     }
 
+    if (stmt->type == NODE_WHILE) {
+        for (int i = 0; i < stmt->data.while_stmt.count; i++) {
+            emit_globals_for_statement(stmt->data.while_stmt.statements[i], outf);
+        }
+        return;
+    }
+
+    if (stmt->type == NODE_FOR) {
+        emit_globals_for_statement(stmt->data.for_stmt.init, outf);
+        for (int i = 0; i < stmt->data.for_stmt.count; i++) {
+            emit_globals_for_statement(stmt->data.for_stmt.statements[i], outf);
+        }
+        emit_globals_for_statement(stmt->data.for_stmt.increment, outf);
+        return;
+    }
+
     if (stmt->type == NODE_IF) {
         for (int i = 0; i < stmt->data.if_stmt.then_count; i++) {
             emit_globals_for_statement(stmt->data.if_stmt.then_statements[i], outf);
@@ -233,6 +249,7 @@ static char* safe_strdup(const char* s) {
 }
 
 static int label_counter = 0;
+static int loop_label_counter = 0;
 
 void llvm_scho(FILE* outf, const char* val_to_print) {
     fprintf(outf, "    call void @cprint(i32 %s)\n", val_to_print);
@@ -319,11 +336,21 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
                 case TOKEN_DIV:    op_str = "sdiv"; break;
                 case TOKEN_MODULO: op_str = "srem"; break;
                 case TOKEN_EQUAL:  op_str = "eq"; break;
+                case TOKEN_NE:     op_str = "ne"; break;
+                case TOKEN_LT:     op_str = "slt"; break;
+                case TOKEN_GT:     op_str = "sgt"; break;
+                case TOKEN_LE:     op_str = "sle"; break;
+                case TOKEN_GE:     op_str = "sge"; break;
                 default:           op_str = "add"; break;
             }
-            if (node->data.binary_op.op == TOKEN_EQUAL) {
+            if (node->data.binary_op.op == TOKEN_EQUAL ||
+                node->data.binary_op.op == TOKEN_NE ||
+                node->data.binary_op.op == TOKEN_LT ||
+                node->data.binary_op.op == TOKEN_GT ||
+                node->data.binary_op.op == TOKEN_LE ||
+                node->data.binary_op.op == TOKEN_GE) {
                 int cmp_reg = (*register_count)++;
-                fprintf(outf, "    %%%d = icmp eq i32 %s, %s\n", cmp_reg, left, right);
+                fprintf(outf, "    %%%d = icmp %s i32 %s, %s\n", cmp_reg, op_str, left, right);
                 int zext_reg = (*register_count)++;
                 fprintf(outf, "    %%%d = zext i1 %%%d to i32\n", zext_reg, cmp_reg);
 
@@ -464,6 +491,71 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
 
         case NODE_FUN_DEF:
             return NULL;
+
+        case NODE_WHILE: {
+            int my_id = loop_label_counter++;
+
+            fprintf(outf, "    br label %%loopcond%d\n", my_id);
+            fprintf(outf, "loopcond%d:\n", my_id);
+
+            char* cond = compile_value_node(outf, node->data.while_stmt.condition, register_count);
+            int cmp_reg = (*register_count)++;
+            fprintf(outf, "    %%%d = icmp ne i32 %s, 0\n", cmp_reg, cond);
+            free(cond);
+            fprintf(outf, "    br i1 %%%d, label %%loopbody%d, label %%loopend%d\n", cmp_reg, my_id, my_id);
+
+            fprintf(outf, "loopbody%d:\n", my_id);
+            int body_returned = 0;
+            for (int i = 0; i < node->data.while_stmt.count; i++) {
+                if (node->data.while_stmt.statements[i]->type == NODE_RETURN) body_returned = 1;
+                char* leftover = compile_node(outf, node->data.while_stmt.statements[i], register_count);
+                if (leftover) free(leftover);
+                if (body_returned) break;
+            }
+            if (!body_returned) {
+                fprintf(outf, "    br label %%loopcond%d\n", my_id);
+            }
+
+            fprintf(outf, "loopend%d:\n", my_id);
+            return NULL;
+        }
+
+        case NODE_FOR: {
+            int my_id = loop_label_counter++;
+
+            if (node->data.for_stmt.init) {
+                char* leftover = compile_node(outf, node->data.for_stmt.init, register_count);
+                if (leftover) free(leftover);
+            }
+
+            fprintf(outf, "    br label %%loopcond%d\n", my_id);
+            fprintf(outf, "loopcond%d:\n", my_id);
+
+            char* cond = compile_value_node(outf, node->data.for_stmt.condition, register_count);
+            int cmp_reg = (*register_count)++;
+            fprintf(outf, "    %%%d = icmp ne i32 %s, 0\n", cmp_reg, cond);
+            free(cond);
+            fprintf(outf, "    br i1 %%%d, label %%loopbody%d, label %%loopend%d\n", cmp_reg, my_id, my_id);
+
+            fprintf(outf, "loopbody%d:\n", my_id);
+            int body_returned = 0;
+            for (int i = 0; i < node->data.for_stmt.count; i++) {
+                if (node->data.for_stmt.statements[i]->type == NODE_RETURN) body_returned = 1;
+                char* leftover = compile_node(outf, node->data.for_stmt.statements[i], register_count);
+                if (leftover) free(leftover);
+                if (body_returned) break;
+            }
+            if (!body_returned) {
+                if (node->data.for_stmt.increment) {
+                    char* leftover = compile_node(outf, node->data.for_stmt.increment, register_count);
+                    if (leftover) free(leftover);
+                }
+                fprintf(outf, "    br label %%loopcond%d\n", my_id);
+            }
+
+            fprintf(outf, "loopend%d:\n", my_id);
+            return NULL;
+        }
 
         case NODE_PROGRAM:
             return NULL;

--- a/tests/for_in.grv
+++ b/tests/for_in.grv
@@ -1,0 +1,3 @@
+for i in 5
+    scho('a')
+end

--- a/tests/for_in.txt
+++ b/tests/for_in.txt
@@ -1,0 +1,31 @@
+; ModuleID = 'output.ll'
+declare i32 @putchar(i32)
+
+@i = global i32 0, align 4
+
+define void @cprint(i32 %charasc) {
+entry:
+    %0 = call i32 @putchar(i32 %charasc)
+    ret void
+}
+
+
+define i32 @main() {
+entry:
+    store i32 0, ptr @i, align 4
+    br label %loopcond0
+loopcond0:
+    %1 = load i32, ptr @i, align 4
+    %2 = icmp slt i32 %1, 5
+    %3 = zext i1 %2 to i32
+    %4 = icmp ne i32 %3, 0
+    br i1 %4, label %loopbody0, label %loopend0
+loopbody0:
+    call void @cprint(i32 97)
+    %5 = load i32, ptr @i, align 4
+    %6 = add i32 %5, 1
+    store i32 %6, ptr @i, align 4
+    br label %loopcond0
+loopend0:
+    ret i32 0
+}

--- a/tests/for_loop.grv
+++ b/tests/for_loop.grv
@@ -1,0 +1,3 @@
+for int i=0; i<5; i++
+    scho('a')
+end

--- a/tests/for_loop.txt
+++ b/tests/for_loop.txt
@@ -1,0 +1,31 @@
+; ModuleID = 'output.ll'
+declare i32 @putchar(i32)
+
+@i = global i32 0, align 4
+
+define void @cprint(i32 %charasc) {
+entry:
+    %0 = call i32 @putchar(i32 %charasc)
+    ret void
+}
+
+
+define i32 @main() {
+entry:
+    store i32 0, ptr @i, align 4
+    br label %loopcond0
+loopcond0:
+    %1 = load i32, ptr @i, align 4
+    %2 = icmp slt i32 %1, 5
+    %3 = zext i1 %2 to i32
+    %4 = icmp ne i32 %3, 0
+    br i1 %4, label %loopbody0, label %loopend0
+loopbody0:
+    call void @cprint(i32 97)
+    %5 = load i32, ptr @i, align 4
+    %6 = add i32 %5, 1
+    store i32 %6, ptr @i, align 4
+    br label %loopcond0
+loopend0:
+    ret i32 0
+}

--- a/tests/while_loop.grv
+++ b/tests/while_loop.grv
@@ -1,0 +1,9 @@
+val counter := 0
+
+while counter < 5
+    counter += 1
+end
+
+if counter == 5
+    scho('a')
+end

--- a/tests/while_loop.txt
+++ b/tests/while_loop.txt
@@ -1,0 +1,41 @@
+; ModuleID = 'output.ll'
+declare i32 @putchar(i32)
+
+@counter = global i32 0, align 4
+
+define void @cprint(i32 %charasc) {
+entry:
+    %0 = call i32 @putchar(i32 %charasc)
+    ret void
+}
+
+
+define i32 @main() {
+entry:
+    store i32 0, ptr @counter, align 4
+    br label %loopcond0
+loopcond0:
+    %1 = load i32, ptr @counter, align 4
+    %2 = icmp slt i32 %1, 5
+    %3 = zext i1 %2 to i32
+    %4 = icmp ne i32 %3, 0
+    br i1 %4, label %loopbody0, label %loopend0
+loopbody0:
+    %5 = load i32, ptr @counter, align 4
+    %6 = add i32 %5, 1
+    store i32 %6, ptr @counter, align 4
+    br label %loopcond0
+loopend0:
+    %7 = load i32, ptr @counter, align 4
+    %8 = icmp eq i32 %7, 5
+    %9 = zext i1 %8 to i32
+    %10 = icmp ne i32 %9, 0
+    br i1 %10, label %then1, label %else2
+then1:
+    call void @cprint(i32 97)
+    br label %end3
+else2:
+    br label %end3
+end3:
+    ret i32 0
+}


### PR DESCRIPTION
Hello,

I came across this repo last night and immediately liked the direction of the language. Loops felt like a natural next step for the language, so I decided to take a crack at it. Closes #34.

## Summary

- `while` loops, matching the existing `if`/`repeat` block style (`while cond ... end`).
- `for` loops, two ways:
  - Classic: `for int i=0; i<10; i++`
  - Modern: `for i in n`, which just desugars into `i := 0`, `i < n`, `i++` at parse time, so both share the same codegen.
- Comparison operators `<`, `>`, `<=`, `>=`, `!=`, with their own precedence level (`a < b == c` parses as `(a < b) == c`).
- `i++` / `i--` and compound assignment `+=`, `-=`, `*=`, `/=`, `%=`.
- Small bug fix: the tokenizer never actually emitted the `,` token, which quietly broke any function with more than one argument.
- Updated the grammar (EBNF), DESIGN.md, and README, plus tests for all three loop forms.

## How it works

Nothing fancy, the new operators all get desugared into existing nodes (`i++` becomes `i = i + 1`), and each loop just gets three LLVM basic blocks (`loopcond`, `loopbody`, `loopend`). Keeps the backend small.

## Testing

- All 9 `tests.py` tests pass, including the three new loop ones.
- Also built with ASan/UBSan, and ran the generated `.ll` through clang and llvmlite.

## Known limitations

- Loop variables are globals (same as every other variable right now), so two nested loops using the same variable name will clobber each other.
- No `break` / `continue` yet.
- `in` is now a reserved word.
- Comparisons aren't constant-folded like the arithmetic ops are.

Open to feedback, happy to adjust anything. Thanks for the project!