### PR TITLE
Added the bitwise operators for |, &, ^ and ~. which are or, and, xor…

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -6,6 +6,7 @@
 typedef enum {
     NODE_LITERAL,
     NODE_BINARY_OP,
+    NODE_UNARY_OP,
     NODE_VARIABLE,
     NODE_DECLARATION,
     NODE_PROGRAM,
@@ -40,6 +41,11 @@ typedef struct ASTNode {
             struct ASTNode* left;
             struct ASTNode* right;
         } binary_op;
+
+        struct {
+            TokenType op;
+            struct ASTNode* operand;
+        } unary_op;
 
         struct {
             char name[64];
@@ -119,6 +125,7 @@ Token* peek(const Token* t, const int* c);
 Token* advance(const Token* t, int* c);
 ASTNode* parse(const Token* tokens, int count);
 ASTNode* parse_primary(const Token* t, int* c, const char* ns);
+ASTNode* parse_unary(const Token* t, int* c, const char* ns);
 ASTNode* parse_multiplicative(const Token* t, int* c, const char* ns);
 ASTNode* parse_additive(const Token* t, int* c, const char* ns);
 ASTNode* parse_equality(const Token* t, int* c, const char* ns);

--- a/include/tokens.h
+++ b/include/tokens.h
@@ -16,7 +16,11 @@ typedef enum {
     TOKEN_NAME,
     TOKEN_TYPEIS_LIST, //for char[][], int[], etc
     TOKEN_EQUAL,
-    TOKEN_AMPERSAND,
+    TOKEN_AMPERSAND, // &
+    TOKEN_PIPE, // |
+    TOKEN_CARET, // ^
+    TOKEN_EXC, // !
+    TOKEN_TILDE, // ~
     TOKEN_NEWLINE,
     TOKEN_RPAREN,
     TOKEN_LPAREN,

--- a/src/ast.c
+++ b/src/ast.c
@@ -189,12 +189,31 @@ static void qualify_name(char* dest, size_t dest_size, const char* ns, const cha
     }
 }
 
+ASTNode* parse_unary(const Token* t, int* c, const char* ns) {
+    if (peek(t, c)->type == TOKEN_TILDE) {
+        Token* op_token = advance(t,c);
+
+        ASTNode* operand = parse_unary(t, c, ns);
+
+        ASTNode* unary_node = (ASTNode*)malloc(sizeof(ASTNode));
+        if (!unary_node) raiseError("Memory allocation failed", "E0004");
+
+        unary_node->type = NODE_UNARY_OP;
+        unary_node->data.unary_op.op = op_token->type;
+        unary_node->data.unary_op.operand = operand;
+
+        return unary_node;
+    }
+
+    return parse_primary(t, c, ns);
+}
+
 ASTNode* parse_multiplicative(const Token* t, int* c, const char* ns) {
-    ASTNode* left = parse_primary(t, c, ns);
+    ASTNode* left = parse_unary(t, c, ns);
     
     while (peek(t, c)->type == TOKEN_STAR || peek(t, c)->type == TOKEN_DIV || peek(t, c)->type == TOKEN_MODULO) {
         Token* op_token = advance(t, c);
-        ASTNode* right = parse_primary(t, c, ns);
+        ASTNode* right = parse_unary(t, c, ns);
 
         if (left->type == NODE_LITERAL && right->type == NODE_LITERAL) {
             int res = fold_literals(op_token->type, left->data.literal.value, right->data.literal.value);
@@ -338,7 +357,23 @@ ASTNode* parse_primary(const Token* t, int* c, const char* ns) {
 }
 
 ASTNode* parse_expression(const Token* t, int* c, const char* ns) {
-    return parse_equality(t, c, ns);
+    ASTNode* left = parse_equality(t, c, ns);
+
+    while(peek(t, c)->type == TOKEN_AMPERSAND || peek(t,c)->type == TOKEN_PIPE ||
+            peek(t, c)->type == TOKEN_CARET){
+        Token* op_token = advance(t,c);
+        ASTNode* right = parse_equality(t, c, ns);
+
+        ASTNode* bin_node = (ASTNode*)malloc(sizeof(ASTNode));
+        if (!bin_node) raiseError("Memory allocation failed", "E0004");
+        bin_node->type = NODE_BINARY_OP;
+        bin_node->data.binary_op.op = op_token->type;
+        bin_node->data.binary_op.left = left;
+        bin_node->data.binary_op.right = right;
+
+        left = bin_node;
+    }
+    return left;
 }
 
 ASTNode* parse_relational(const Token* t, int* c, const char* ns) {

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -143,8 +143,18 @@ void tokenize(const char* file, ARGS_CONTEX* ctx) {
                     tokens[token_count].type = TOKEN_NE;
                     source++;
                 } else {
-                    raiseError("Unexpected token '!'", "E0001");
+                    // Not doing anything yet
+                    tokens[token_count].type = TOKEN_EXC;
                 }
+                break;
+            case '~':
+                tokens[token_count].type = TOKEN_TILDE;
+                break;
+            case '|':
+                tokens[token_count].type = TOKEN_PIPE;
+                break;
+            case '^':
+                tokens[token_count].type = TOKEN_CARET;
                 break;
             case ';':
                 tokens[token_count].type = TOKEN_SEMICOLON;

--- a/src/tollvm.c
+++ b/src/tollvm.c
@@ -341,6 +341,9 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
                 case TOKEN_GT:     op_str = "sgt"; break;
                 case TOKEN_LE:     op_str = "sle"; break;
                 case TOKEN_GE:     op_str = "sge"; break;
+                case TOKEN_AMPERSAND:  op_str = "and"; break;
+                case TOKEN_PIPE:   op_str = "or"; break;
+                case TOKEN_CARET:  op_str = "xor"; break;
                 default:           op_str = "add"; break;
             }
             if (node->data.binary_op.op == TOKEN_EQUAL ||
@@ -370,6 +373,27 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
                 char buf[32];
                 snprintf(buf, sizeof(buf), "%%%d", reg);
                 return safe_strdup(buf);
+            }
+        }
+
+        case NODE_UNARY_OP: {
+            char* operand = compile_value_node(outf, node->data.unary_op.operand, register_count);
+            
+            const char* op_str = "";
+            switch(node->data.binary_op.op) {
+                case TOKEN_TILDE:    op_str = "add"; 
+                    int reg = (*register_count)++;
+                    fprintf(outf, "    %%%d = xor i32 %s, -1\n", reg, operand);
+                    free(operand);
+
+                    char buf[32];
+                    snprintf(buf, sizeof(buf), "%%%d", reg);
+                    return safe_strdup(buf);
+                    break;
+                default:
+                    raiseError("Unsupported unary operator", "E0033");
+                    free(operand);
+                    return NULL;
             }
         }
 

--- a/tests/bitwise.grv
+++ b/tests/bitwise.grv
@@ -1,0 +1,10 @@
+val xor := 1 ^ 1
+xor = xor ^ 0
+
+val and := 0 & 1
+and = and & 1
+
+val or  := 0 | 0
+or = or | 1
+
+val bit_not := ~1

--- a/tests/bitwise.txt
+++ b/tests/bitwise.txt
@@ -1,0 +1,36 @@
+; ModuleID = 'output.ll'
+declare i32 @putchar(i32)
+
+@xor = global i32 0, align 4
+@and = global i32 0, align 4
+@or = global i32 0, align 4
+@bit_not = global i32 0, align 4
+
+define void @cprint(i32 %charasc) {
+entry:
+    %0 = call i32 @putchar(i32 %charasc)
+    ret void
+}
+
+
+define i32 @main() {
+entry:
+    %1 = xor i32 1, 1
+    store i32 %1, ptr @xor, align 4
+    %2 = load i32, ptr @xor, align 4
+    %3 = xor i32 %2, 0
+    store i32 %3, ptr @xor, align 4
+    %4 = and i32 0, 1
+    store i32 %4, ptr @and, align 4
+    %5 = load i32, ptr @and, align 4
+    %6 = and i32 %5, 1
+    store i32 %6, ptr @and, align 4
+    %7 = or i32 0, 0
+    store i32 %7, ptr @or, align 4
+    %8 = load i32, ptr @or, align 4
+    %9 = or i32 %8, 1
+    store i32 %9, ptr @or, align 4
+    %10 = xor i32 1, -1
+    store i32 %10, ptr @bit_not, align 4
+    ret i32 0
+}


### PR DESCRIPTION
## Addition
I added 4  bitwise operations, which are
- "|" for or
- "&" for and
- "^" for xor
- "~" for bitwise not, which flips all the bits of an int, different from "!"

## Descriptoin
- Placed `~` in `parse_unary()`, giving it higher precedence than multiplicative operators (`*`, `/`, `%`) but lower than primary expressions (literals, grouping `()`, identifiers).
- I placed `|`, `&`, and `^` at an equal precedence level (below equality, left-associative).
- The precedence of these tokens is up for discussion; they can be easily moved around
- I have also added a new test for bitwise operations that I outlined above

Associated ticket: #44 

## Test code

```
val xor := 1 ^ 1
xor = xor ^ 0

val and := 0 & 1
and = and & 1

val or  := 0 | 0
or = or | 1

val bit_not := ~1
```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation
- [ ] CI/CD or Infrastructure configuration

## How has this been tested?
- [x] Unit tests passed locally.
- [x] Integration tests executed successfully.
- [x] Python tests

## Screenshots (if applicable)

## Checklist
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented on parts of the code that are difficult to understand.
- [ ] I have updated the corresponding documentation.
- [x] The new changes do not generate any warnings or compilation errors.
- [x] All tests (including Python tests) pass.
