### PR TITLE
Remove duplicate fuzzing command

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -93,6 +93,3 @@ jobs:
         clang -fsanitize=fuzzer,address,undefined -Dmain=gravel_main -Wl,--wrap=exit src/*.c tests/fuzz_target.c -o fuzzer
         
         env ASAN_OPTIONS="detect_leaks=0" ./fuzzer -max_total_time=30 -close_fd_mask=3
-        clang -fsanitize=fuzzer,address,undefined -Dmain=gravel_main -Wl,--wrap=exit src/*.c tests/fuzz_target.c -o fuzzer
-        
-        env ASAN_OPTIONS="detect_leaks=0" ./fuzzer -max_total_time=30 -close_fd_mask=3


### PR DESCRIPTION
Removed duplicate fuzzing command in sanitizers.yml.

## Description

Associated ticket: #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation
- [ ] CI/CD or Infrastructure configuration

## How has this been tested?
- [ ] Unit tests passed locally.
- [ ] Integration tests executed successfully.
- [ ] Python tests

## Screenshots (if applicable)

## Checklist
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on parts of the code that are difficult to understand.
- [ ] I have updated the corresponding documentation.
- [ ] The new changes do not generate any warnings or compilation errors.
- [ ] All tests (including Python tests) pass.
