### PR TITLE
Continue float type. Missing: overload symbols for float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,3 +213,4 @@
 - Continue float type. Missing: overload symbols for `float`
 
 TODO: Add checker, imports and packages to documentation
+KNOWN BUGS: void functions return 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,10 +203,13 @@
 - Add `float` type
 - Add packages and import
 
-### 1016-08-21
+### 2026-08-21
 - Make `Cargo.grvdep` work
 - Move changelog to a separated file
 - Cargo.grvdep can have libraries hosted in the web
 - Update extension to show icons at `.grvdep` files
+
+### 2026-08-22
+- COntinue float type. Missing: overload symbols for `float`
 
 TODO: Add checker, imports and packages to documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,6 @@
 - Update extension to show icons at `.grvdep` files
 
 ### 2026-08-22
-- COntinue float type. Missing: overload symbols for `float`
+- Continue float type. Missing: overload symbols for `float`
 
 TODO: Add checker, imports and packages to documentation

--- a/Cargo.grvdep
+++ b/Cargo.grvdep
@@ -1,1 +1,0 @@
-web:https://raw.githubusercontent.com/Pacsfury/Gravel-Launcher/refs/heads/main/libs/math.grv

--- a/include/ast.h
+++ b/include/ast.h
@@ -51,6 +51,7 @@ typedef struct ASTNode {
         struct {
             char name[64];
             struct ASTNode* value;
+            char type[64];
         } var_decl;
 
         struct {

--- a/include/tollvm.h
+++ b/include/tollvm.h
@@ -11,3 +11,5 @@ void llvm_scho(FILE* outf, const char* val_to_print);
 int to_llvm_ir(const Token* tokens, int token_count, ARGS_CONTEX* ctx);
 
 static char* compile_node(FILE* outf, ASTNode* node, int* register_count);
+
+static const char* llvm_type_for(const char* type_name);

--- a/main.grv
+++ b/main.grv
@@ -1,5 +1,0 @@
-import "math" // Cargo.grvdep handles the path for me
-
-if math.factorial(5) == 120
-    scho('a')
-end

--- a/main.grv
+++ b/main.grv
@@ -1,0 +1,7 @@
+fun sum(int a, int b)
+    scho('g')
+end
+
+if sum(8, 8) == 0
+    scho('a')
+end

--- a/src/ast.c
+++ b/src/ast.c
@@ -513,18 +513,35 @@ ASTNode* parse_statement(const Token* t, int* c, const char* ns, ARGS_CONTEX* ct
 
         if (peek(t, c)->type == TOKEN_VAR_INFER) {
             advance(t, c);
-        } else {
-            raiseError("Missing ':='  in variable declaration", "E0006");
-        }
+            result->data.var_decl.value = parse_expression(t, c, ns, ctx);
 
-        result->data.var_decl.value = parse_expression(t, c, ns, ctx);
-        return result;
+            if (result->data.var_decl.value && result->data.var_decl.value->type == NODE_LITERAL &&
+                strchr(result->data.var_decl.value->data.literal.value, '.') != NULL) {
+                strcpy(result->data.var_decl.type, "float");
+            } else {
+                strcpy(result->data.var_decl.type, "int");
+            }
+        } else {
+            raiseError("Missing ':=' in variable declaration", "E0006");
+        }
+        
+        if (result->data.var_decl.value)
+            return result;
+
+        return NULL;
     } else if (current->type == TOKEN_INT || current->type == TOKEN_FLOAT || current->type == TOKEN_CHAR) {
         ASTNode* result = (ASTNode*)malloc(sizeof(ASTNode));
         if (!result)
             raiseError("Memory allocation failed", "E0004");
 
         result->type = NODE_DECLARATION;
+
+        if (current->type == TOKEN_INT) {
+            strcpy(result->data.var_decl.type, "int");
+        } else if (current->type == TOKEN_FLOAT) {
+            strcpy(result->data.var_decl.type, "float");
+        }
+
         advance(t, c);
 
         if (peek(t, c)->type == TOKEN_NAME) {

--- a/src/tollvm.c
+++ b/src/tollvm.c
@@ -20,6 +20,7 @@ static char current_function_param_names[32][64];
 static char* current_function_param_ptrs[32];
 static char current_function_param_types[32][32];
 static char emitted_funcs[MAX_EMITTED_FUNCS][256];
+static char emitted_globals_types[MAX_EMITTED_GLOBALS][32];
 static char emitted_funcs_ret[MAX_EMITTED_FUNCS][32];
 static int emitted_funcs_count = 0;
 
@@ -49,10 +50,21 @@ static int already_emitted(const char* name) {
     return 0;
 }
 
-static void mark_emitted(const char* name) {
+static void mark_emitted(const char* name, const char* type) {
     if (emitted_globals_count < MAX_EMITTED_GLOBALS) {
-        strcpy(emitted_globals[emitted_globals_count++], name);
+        strcpy(emitted_globals[emitted_globals_count], name);
+        strcpy(emitted_globals_types[emitted_globals_count], type); // Save the type
+        emitted_globals_count++;
     }
+}
+
+static const char* lookup_global_type(const char* name) {
+    for (int i = 0; i < emitted_globals_count; i++) {
+        if (strcmp(emitted_globals[i], name) == 0) {
+            return emitted_globals_types[i];
+        }
+    }
+    return "i32"; // Fallback
 }
 
 static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
@@ -61,8 +73,9 @@ static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
 
     if (stmt->type == NODE_DECLARATION || stmt->type == NODE_CONSTANT) {
         if (!already_emitted(stmt->data.var_decl.name)) {
-            fprintf(outf, "@%s = global %s %s, align 4\n", stmt->data.var_decl.name, llvm_type_for(stmt->data.var_decl.type), strcmp(llvm_type_for(stmt->data.var_decl.type), "float") == 0 ? "0.0" : "0");
-            mark_emitted(stmt->data.var_decl.name);
+            const char* type_str = llvm_type_for(stmt->data.var_decl.type);
+            fprintf(outf, "@%s = global %s %s, align 4\n", stmt->data.var_decl.name, type_str, strcmp(type_str, "float") == 0 ? "0.0" : "0");
+            mark_emitted(stmt->data.var_decl.name, type_str);
         }
         return;
     }
@@ -70,9 +83,9 @@ static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
     if (stmt->type == NODE_REASSIGN) {
         if (!already_emitted(stmt->data.var_decl.name)) {
             raiseError("An undeclared variable cannot be reassigned", "E0030");
-        }
+        } 
         return;
-    }
+    } 
 
     if (stmt->type == NODE_FUN_DEF && stmt->data.fun_def.body && stmt->data.fun_def.body->type == NODE_PROGRAM) {
         for (int i = 0; i < stmt->data.fun_def.body->data.program.count; i++) {
@@ -122,7 +135,7 @@ static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
 
 static const char* llvm_type_for(const char* type_name) {
     if (!type_name || type_name[0] == '\0')
-        return "void";
+        return "i32";
     if (strcmp(type_name, "int") == 0)
         return "i32";
     if (strcmp(type_name, "float") == 0)
@@ -327,7 +340,8 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
             }
 
             int reg = (*register_count)++;
-            fprintf(outf, "    %%%d = load %s, ptr @%s, align 4\n", reg, node->data.literal.value, llvm_type_for(node->data.var_decl.type));
+
+            fprintf(outf, "    %%%d = load %s, ptr @%s, align 4\n", reg, lookup_global_type(node->data.literal.value), node->data.literal.value);
 
             char buf[32];
             snprintf(buf, sizeof(buf), "%%%d", reg);
@@ -629,11 +643,16 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
             fprintf(outf, "    br label %%loopcond%d\n", my_id);
             fprintf(outf, "loopcond%d:\n", my_id);
 
-            char* cond = compile_value_node(outf, node->data.for_stmt.condition, register_count);
-            int cmp_reg = (*register_count)++;
-            fprintf(outf, "    %%%d = icmp ne i32 %s, 0\n", cmp_reg, cond);
-            free(cond);
-            fprintf(outf, "    br i1 %%%d, label %%loopbody%d, label %%loopend%d\n", cmp_reg, my_id, my_id);
+            // Handle missing condition (infinite loop)
+            if (node->data.for_stmt.condition) {
+                char* cond = compile_value_node(outf, node->data.for_stmt.condition, register_count);
+                int cmp_reg = (*register_count)++;
+                fprintf(outf, "    %%%d = icmp ne i32 %s, 0\n", cmp_reg, cond);
+                free(cond);
+                fprintf(outf, "    br i1 %%%d, label %%loopbody%d, label %%loopend%d\n", cmp_reg, my_id, my_id);
+            } else {
+                fprintf(outf, "    br label %%loopbody%d\n", my_id);
+            }
 
             fprintf(outf, "loopbody%d:\n", my_id);
             int body_returned = 0;

--- a/src/tollvm.c
+++ b/src/tollvm.c
@@ -61,7 +61,7 @@ static void emit_globals_for_statement(ASTNode* stmt, FILE* outf) {
 
     if (stmt->type == NODE_DECLARATION || stmt->type == NODE_CONSTANT) {
         if (!already_emitted(stmt->data.var_decl.name)) {
-            fprintf(outf, "@%s = global i32 0, align 4\n", stmt->data.var_decl.name);
+            fprintf(outf, "@%s = global %s %s, align 4\n", stmt->data.var_decl.name, llvm_type_for(stmt->data.var_decl.type), strcmp(llvm_type_for(stmt->data.var_decl.type), "float") == 0 ? "0.0" : "0");
             mark_emitted(stmt->data.var_decl.name);
         }
         return;
@@ -275,6 +275,21 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
                 snprintf(buf, sizeof(buf), "%d", (int)(unsigned char)v[0]);
                 return safe_strdup(buf);
             }
+
+            // If the literal is a float (contains a decimal), convert to LLVM's exact hex format
+            if (strchr(v, '.') && (isdigit((unsigned char)v[0]) || v[0] == '-')) {
+                float f = (float)atof(v);
+                double d = (double)f; 
+                unsigned long long hex = 0;
+                
+                // Copy the exact bits of the double into an integer
+                memcpy(&hex, &d, sizeof(double)); 
+                
+                char buf[32];
+                snprintf(buf, sizeof(buf), "0x%llX", hex);
+                return safe_strdup(buf);
+            }
+
             return safe_strdup(v);
         }
 
@@ -312,7 +327,7 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
             }
 
             int reg = (*register_count)++;
-            fprintf(outf, "    %%%d = load i32, ptr @%s, align 4\n", reg, node->data.literal.value);
+            fprintf(outf, "    %%%d = load %s, ptr @%s, align 4\n", reg, node->data.literal.value, llvm_type_for(node->data.var_decl.type));
 
             char buf[32];
             snprintf(buf, sizeof(buf), "%%%d", reg);
@@ -323,7 +338,7 @@ static char* compile_node(FILE* outf, ASTNode* node, int* register_count) {
         case NODE_DECLARATION: {
             if (node->data.var_decl.value) {
                 char* val = compile_value_node(outf, node->data.var_decl.value, register_count);
-                fprintf(outf, "    store i32 %s, ptr @%s, align 4\n", val, node->data.var_decl.name);
+                fprintf(outf, "    store %s %s, ptr @%s, align 4\n", llvm_type_for(node->data.var_decl.type), val, node->data.var_decl.name);
                 free(val);
             }
             return NULL;

--- a/tests/functions.txt
+++ b/tests/functions.txt
@@ -9,10 +9,10 @@ entry:
 }
 
 
-define void @voidFun() {
+define i32 @voidFun() {
 entry:
     call void @cprint(i32 0)
-    ret void
+    ret i32 0
 }
 
 define i32 @intFun() {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,7 +26,7 @@ def execute(file):
     if expected_path.read_text(encoding="utf-8").strip() != output_path.read_text(encoding="utf-8").strip():
         print(f"File {file} failed verification.")
 
-        print(f"\n\n{expected_path.read_text(encoding="utf-8").strip()}\n\n{output_path.read_text(encoding="utf-8").strip()}\n\n")
+        print(f'\n\n{expected_path.read_text(encoding="utf-8").strip()}\n\n{output_path.read_text(encoding="utf-8").strip()}\n\n')
         return 1
     
     print(f"{file} passed successfully.")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -25,6 +25,8 @@ def execute(file):
 
     if expected_path.read_text(encoding="utf-8").strip() != output_path.read_text(encoding="utf-8").strip():
         print(f"File {file} failed verification.")
+
+        print(f"\n\n{expected_path.read_text(encoding="utf-8").strip()}\n\n{output_path.read_text(encoding="utf-8").strip()}\n\n")
         return 1
     
     print(f"{file} passed successfully.")


### PR DESCRIPTION
## Description

Associated ticket: #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation
- [ ] CI/CD or Infrastructure configuration

## How has this been tested?
- [ ] Unit tests passed locally.
- [ ] Integration tests executed successfully.
- [ ] Python tests

## Screenshots (if applicable)

## Checklist
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on parts of the code that are difficult to understand.
- [ ] I have updated the corresponding documentation.
- [ ] The new changes do not generate any warnings or compilation errors.
- [ ] All tests (including Python tests) pass.
