### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/6](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/6)

Add an explicit `permissions` block in `.github/workflows/windows-ci.yml` at the workflow root (top level), so it applies to all jobs unless overridden. For this workflow, the least-privilege baseline is sufficient:

- `contents: read`

This preserves existing behavior (checkout and build/run still work) while preventing accidental broader token scopes if repository/org defaults change. The best single fix is to insert the block after the `on:` triggers and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
