### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/1](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.  
Best fix here: add a workflow-level permission block right after the triggers and before `jobs`, with `contents: read`. This preserves current functionality (checkout and test execution still work) while enforcing least privilege for all jobs in this workflow.

File to change:
- `.github/workflows/tests.yml`

Specific change:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it between the `on:` section and `jobs:` section.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
