### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/3](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions right after the `on:` block (or before `jobs:`), since there is one job and no step needs write permissions. Use:

- `contents: read`

This preserves existing functionality (`actions/checkout` and local compile/run) while preventing broader implicit token permissions.

Edit only `.github/workflows/macos-ci.yml` and insert the `permissions` block at the root level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
