### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/4](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (applies to all jobs unless overridden), with `contents: read`, which is sufficient for `actions/checkout` and this read/CI-only job behavior.

Edit only `.github/workflows/sanitizers.yml`, near the top-level keys (`name`, `on`, `jobs`), inserting:

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
