### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/5](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so token scope is documented and constrained regardless of repository/org defaults.

Best fix here (without changing behavior): add workflow-level permissions with `contents: read` directly under the `on` section (before `jobs`). This applies to all jobs unless overridden and is sufficient for `actions/checkout` and local compile/run steps shown.

File to change:
- `.github/workflows/ubuntu-ci.yml`
  - Insert:
    ```yaml
    permissions:
      contents: read
    ```
  - Place it at top level between `on:` and `jobs:` (or any top-level position).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
