### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/2](https://github.com/Pacsfury/Gravel-Launcher/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default. The best minimal fix here is at the workflow root (top-level), since there is only one job shown and no indication of job-specific elevated needs. Set:

- `contents: read`

This preserves current functionality (checkout and build) while enforcing least privilege.

**File/region to change:** `.github/workflows/freebsd-ci.yml`, between the `on:` trigger section and `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
